### PR TITLE
Add score thresholding functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ command line:
 - [ ] Custom genetic code (`aragorn -gc<n>,BBB=<aa>`).
 - [x] Circular and linear topologies (`aragorn -c` | `aragorn -l`).
 - [ ] Intron length configuration (`aragorn -i`).
-- [ ] Scoring threshold configuration (`aragorn -ps`).
+- [x] Scoring threshold configuration (`aragorn -ps`).
 - [x] Sequence extraction from RNA gene (`aragorn -seq`).
 - [ ] Secondary structure extraction from each gene (`aragorn -br`).
 
@@ -172,4 +172,3 @@ the [Zeller Lab](https://zellerlab.org).*
 
 - <a id="ref1">\[1\]</a> Laslett, Dean, and Bjorn Canback. “ARAGORN, a program to detect tRNA genes and tmRNA genes in nucleotide sequences.” Nucleic acids research vol. 32,1 11-6. 2 Jan. 2004, [doi:10.1093/nar/gkh152](https://doi.org/10.1093/nar/gkh152)
 - <a id="ref2">\[2\]</a> Laslett, Dean, and Björn Canbäck. “ARWEN: a program to detect tRNA genes in metazoan mitochondrial nucleotide sequences.” Bioinformatics (Oxford, England) vol. 24,2 (2008): 172-5. [doi:10.1093/bioinformatics/btm573](https://doi.org/10.1093/bioinformatics/btm573)
-

--- a/include/aragorn.pxd
+++ b/include/aragorn.pxd
@@ -43,7 +43,7 @@ cdef extern from "aragorn.h" nogil:
     const size_t ATBOND
 
     cdef bint space(char c)
-    cdef long int sq(long int pos) 
+    cdef long int sq(long int pos)
 
     cdef enum base:
         INSERT
@@ -273,6 +273,7 @@ cdef extern from "aragorn.h" nogil:
     # tmrna_tag_entry[NTAGMAX] tagdatabase
 
     char* aa(int* anticodon, csw* sw)
+    void change_thresholds(csw *sw, double psthresh)
     void bopt_fastafile(data_set *d, csw *sw)
     void batch_gene_set(data_set* d, int nt, csw* sw)
     char cbase(int c)

--- a/src/pyaragorn/lib.pyi
+++ b/src/pyaragorn/lib.pyi
@@ -20,6 +20,8 @@ class Gene:
     def strand(self) -> Literal[1, -1]: ...
     @property
     def energy(self) -> float: ...
+    @property
+    def raw_energy(self) -> float: ...
     def sequence(self) -> str: ...
  
 class TRNAGene(Gene):
@@ -64,6 +66,7 @@ class RNAFinder(Generic[G]):
         tmrna: Literal[False],
         trna: Literal[True] = True,
         linear: bool = False,
+        ps: float = 100.0,
     ) -> None: ...
     @typing.overload
     def __init__(
@@ -73,6 +76,7 @@ class RNAFinder(Generic[G]):
         trna: Literal[False],
         tmrna: Literal[True] = True,
         linear: bool = False,
+        ps: float = 100.0,
     ) -> None: ...
     @typing.overload
     def __init__(
@@ -82,6 +86,7 @@ class RNAFinder(Generic[G]):
         trna: bool = True,
         tmrna: bool = True,
         linear: bool = False,
+        ps: float = 100.0,
     ) -> None: ...
     def find_rna(
         self,


### PR DESCRIPTION
This PR adds the score thresholding functionality from ARAGORN (`-ps`) to pyARAGORN. `ps` is passed as a parameter to `RNAFinder` and, as in ARAGORN, the value represents a percentage.

In addition, the following features were also added:

- New property `raw_energy` in `Gene` that returns the underlying ARAGORN energy as a `float`.

- Implemented `__repr__` for `TRNAGene`, `TMRNAGene` and `RNAFinder`.